### PR TITLE
fix: load js/main.js and restore site interactivity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1209,6 +1209,17 @@ Footer
     bottom: 25px;
     right: 30px;
     opacity: 0;
+    /* Without these the button is invisible but still clickable and still in
+       the tab order, parked over the bottom-right corner of every page. */
+    visibility: hidden;
+    pointer-events: none;
+    /* Must stay "all": this rule is later than .effect's "transition: all .4s"
+       at equal specificity, so narrowing it here would silently kill the
+       hover background and color fade this button inherits from .effect. */
+    -webkit-transition: all .3s ease;
+    -o-transition: all .3s ease;
+    -moz-transition: all .3s ease;
+    transition: all .3s ease;
     z-index: 60;
 }
 
@@ -1223,6 +1234,8 @@ Footer
 
 .show-up-btn {
     opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 #credit {

--- a/docs/superpowers/plans/2026-08-12-restore-site-interactivity.md
+++ b/docs/superpowers/plans/2026-08-12-restore-site-interactivity.md
@@ -1,0 +1,728 @@
+# Restore Site Interactivity (issue #16) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Load `js/main.js` on `index.html` and make every interaction it defines actually work, after stripping it down to the code that has a matching element in the markup.
+
+**Architecture:** `js/main.js` shrinks from 664 lines to roughly 130 by deleting the blocks that target elements no page contains (magnific-popup, owl carousel, isotope/imagesLoaded, particles, the commented-out typer and AJAX contact form) and the `jQuery.scrollSpeed` mousewheel hijack. What remains is one scroll handler that drives sticky nav, active-link tracking, and skill bars, plus click handlers for anchor scrolling, scroll-to-top, and mobile nav collapse. `index.html` gets the script tag back plus three markup fixes. Because the repo has no test runner, the automated gate is a new standard-library Python checker, `tools/verify_interactivity.py`, that asserts the wiring invariants statically; behavior is proven by a browser drive in Phase 6.
+
+**Tech Stack:** Vanilla HTML5/CSS3, jQuery 2.2.4, Bootstrap 3. No build step, no package manager, no CI. Python 3 standard library for the checker.
+
+## Global Constraints
+
+- No emojis anywhere: code, comments, commit messages, PR text.
+- No em dashes (`-`-style long dash) anywhere. Use commas, periods, or colons.
+- JavaScript only, never TypeScript.
+- No build system. `tools/` holds standalone scripts run by hand, never a build step.
+- Do not reintroduce a library without an element that actually uses it.
+- Do not run `git commit` or `git push`. This project grants no git exception, so the run stops before Phase 9 and hands the commands to the user.
+- Target the `main` branch as it actually is. The untracked `CLAUDE.md` describes the unmerged issue #15 branch (hero WebP variants, `tools/verify_assets.py`, removed libraries); none of that exists here.
+
+## Decisions already approved
+
+| Question | Decision |
+|---|---|
+| Hero parallax | Drop it. Delete `parallax()` from `main.js` and the `parallax` class from `index.html:87`. `.home-1` uses `background-size: cover`, so shifting `backgroundPosition` slides the image down and exposes blank space under the dark overlay. |
+| Smooth scroll | Delete `jQuery.scrollSpeed` (the mousewheel override). Keep the jQuery anchor animation so `data-speed` still applies. Do **not** add CSS `scroll-behavior: smooth`; it fights `animate()`. |
+| Skill bar no-JS fallback | Accept the gap. `data-percent` drives the width; with JS off the bars sit at the 5% CSS default. The portfolio section already hard-requires JS. |
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| Create `tools/verify_interactivity.py` | Standalone checker for the wiring invariants. Standard library only, exits non-zero with a reason per failure. |
+| Rewrite `js/main.js` | The only site-wide behavior file. Every block must have a matching element in `index.html`. |
+| Modify `index.html` | Add the `main.js` tag, `one-page-section` on `#portfolio`, `data-percent` on the three skill bars, drop the `parallax` class, guard the portfolio card click handler. |
+| Modify `css/style.css:1199-1226` | Make `.scroll-up` genuinely hidden rather than just transparent. |
+| Modify `CLAUDE.md` | Delete the "js/main.js is not loaded" warning and correct the line references it anchors. |
+
+---
+
+### Task 1: Verification checker (red)
+
+Write the gate first and watch it fail against the current tree. Every check maps to an acceptance criterion or a defect named in issue #16.
+
+**Files:**
+- Create: `tools/verify_interactivity.py`
+
+**Interfaces:**
+- Produces: a CLI gate, `python3 tools/verify_interactivity.py`, exit 0 on pass and 1 on failure. Later tasks are complete when it exits 0.
+
+- [ ] **Step 1: Write the checker**
+
+```python
+#!/usr/bin/env python3
+"""Verify the site's interactive JavaScript is actually wired up.
+
+Standalone, standard library only, run by hand from the repo root:
+
+    python3 tools/verify_interactivity.py
+
+Exits 0 when the issue #16 acceptance criteria still hold at the source
+level: index.html loads js/main.js after jQuery, every section a nav link
+points at takes part in active-link tracking, every skill bar carries a
+data-percent instead of a hardcoded inline width, the portfolio card click
+handler yields to real anchors, and js/main.js references nothing the
+markup does not contain.
+
+Behavior (does the navbar actually go sticky, does the bar actually
+animate) cannot be checked here. Drive that in a browser.
+"""
+
+import shutil
+import subprocess
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX = ROOT / "index.html"
+MAIN_JS = ROOT / "js" / "main.js"
+
+failures = []
+
+
+def fail(message):
+    failures.append(message)
+
+
+class IndexFacts(HTMLParser):
+    """Collect the few facts about index.html that the checks below need."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.scripts = []        # src of every <script src=...>
+        self.ids = {}            # id -> set of class tokens
+        self.nav_targets = []    # fragment of every <a class="scroll" href="#...">
+        self.progress_bars = []  # (data-percent, style) per .progress-bar-line
+        self.parallax = []       # tag name of every element with class "parallax"
+
+    def handle_starttag(self, tag, attrs):
+        attr = dict(attrs)
+        classes = set((attr.get("class") or "").split())
+
+        if tag == "script" and attr.get("src"):
+            self.scripts.append(attr["src"])
+
+        if attr.get("id"):
+            self.ids[attr["id"]] = classes
+
+        if tag == "a" and "scroll" in classes:
+            href = attr.get("href") or ""
+            if href.startswith("#") and len(href) > 1:
+                self.nav_targets.append(href[1:])
+
+        if "progress-bar-line" in classes:
+            self.progress_bars.append((attr.get("data-percent"), attr.get("style")))
+
+        if "parallax" in classes:
+            self.parallax.append(tag)
+
+
+def check_script_tag(facts):
+    """main.js has to load, and it has to load after jQuery."""
+    if "js/main.js" not in facts.scripts:
+        fail(
+            "index.html does not load js/main.js. The tag was dropped in "
+            "eba0f7b and every interaction in that file died with it."
+        )
+        return
+
+    jquery = [i for i, src in enumerate(facts.scripts) if "jquery.min.js" in src]
+    if not jquery:
+        fail("index.html loads js/main.js but not jQuery; main.js is jQuery code.")
+    elif facts.scripts.index("js/main.js") < jquery[0]:
+        fail("js/main.js is loaded before jQuery, so it throws on load.")
+
+
+def check_nav_targets(facts):
+    """ChangeClass() only sees sections carrying one-page-section."""
+    for target in facts.nav_targets:
+        classes = facts.ids.get(target)
+        if classes is None:
+            fail("A nav link points at #%s but no element has that id." % target)
+        elif "one-page-section" not in classes:
+            fail(
+                "#%s lacks the one-page-section class, so its nav link never "
+                "highlights." % target
+            )
+
+
+def check_progress_bars(facts):
+    """Bars animate from the CSS 5% default to data-percent."""
+    if not facts.progress_bars:
+        fail("No .progress-bar-line elements found in index.html.")
+
+    for value, style in facts.progress_bars:
+        if value is None:
+            fail(
+                "A .progress-bar-line has no data-percent, so main.js would "
+                "set its width to 'undefined%'."
+            )
+        elif not value.isdigit() or int(value) > 100:
+            fail("A .progress-bar-line has data-percent=%r, not an integer 0-100." % value)
+
+        if style and "width" in style:
+            fail(
+                "A .progress-bar-line still hardcodes width in its style "
+                "attribute (%r), which pins it at the final value." % style
+            )
+
+
+def check_card_handler(html):
+    """Clicking Live Demo or Code must not also fire the card handler."""
+    if "portfolio-card" not in html:
+        return
+    if "closest('a')" not in html and 'closest("a")' not in html:
+        fail(
+            "The portfolio card click handler does not bail out on anchor "
+            "clicks, so clicking Live Demo or Code opens two tabs."
+        )
+
+
+def check_no_dead_code(facts, js):
+    """Nothing in main.js may target an element or library the page lacks."""
+    banned = [
+        ("magnificPopup", "no .popup-youtube or .popup-link element exists"),
+        ("owlCarousel", "no .home-carousel or .testimonial-slider element exists"),
+        ("isotope", "no '#work .filtr-container' element exists"),
+        ("imagesLoaded", "only the deleted isotope block used it"),
+        ("particlesJS", "index.html never loads js/particles.js"),
+        ("typer", "the typer initialization was deleted"),
+        ("scrollSpeed", "the mousewheel hijack was removed; it overrode native scrolling"),
+        ("mousewheel", "the mousewheel hijack was removed; it overrode native scrolling"),
+        ("parallax", "the hero uses background-size: cover, so moving backgroundPosition exposes blank space"),
+        ("progress-cont", "no .progress-cont span exists in the markup"),
+    ]
+    for token, reason in banned:
+        if token in js:
+            fail("js/main.js still references %r: %s." % (token, reason))
+
+    if facts.parallax:
+        fail(
+            "index.html still puts the parallax class on <%s>, but nothing "
+            "implements it." % ">, <".join(facts.parallax)
+        )
+
+
+def check_syntax():
+    """Optional: node is a convenience here, never a project dependency."""
+    if shutil.which("node") is None:
+        print("skip: node not found, cannot syntax-check js/main.js")
+        return
+    result = subprocess.run(
+        ["node", "--check", str(MAIN_JS)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail("js/main.js is not valid JavaScript:\n%s" % result.stderr.strip())
+
+
+def main():
+    html = INDEX.read_text(encoding="utf-8")
+    js = MAIN_JS.read_text(encoding="utf-8")
+
+    facts = IndexFacts()
+    facts.feed(html)
+
+    check_script_tag(facts)
+    check_nav_targets(facts)
+    check_progress_bars(facts)
+    check_card_handler(html)
+    check_no_dead_code(facts, js)
+    check_syntax()
+
+    if failures:
+        print("FAIL: %d check(s) failed\n" % len(failures))
+        for message in failures:
+            print("  - %s" % message)
+        return 1
+
+    print("PASS: site interactivity is wired up")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run it against the untouched tree to verify it fails**
+
+Run: `python3 tools/verify_interactivity.py; echo "exit=$?"`
+
+Expected: `exit=1`, with failures naming at least the missing `main.js` tag, `#portfolio` lacking `one-page-section`, three skill bars with no `data-percent` and a hardcoded `width`, the unguarded card handler, the `parallax` class on `<section>`, and the `magnificPopup` / `owlCarousel` / `isotope` / `particlesJS` / `scrollSpeed` / `mousewheel` / `parallax` / `progress-cont` references in `js/main.js`.
+
+If any of those do **not** appear, the check is wrong, not the tree. Fix the checker before moving on.
+
+---
+
+### Task 2: Rewrite js/main.js (green, JavaScript side)
+
+**Files:**
+- Rewrite: `js/main.js` (currently 664 lines)
+
+**Interfaces:**
+- Consumes: jQuery 2.2.4 and the Bootstrap 3 collapse plugin, both already loaded by `index.html`.
+- Produces: the DOM contract Task 3 must satisfy: an element per nav `href` carrying `one-page-section`, `.progress-bar-line[data-percent]`, `.skills-section`, `.scroll-up`, `.nav-wrapper`, `a.scroll`.
+
+- [ ] **Step 1: Replace the whole file**
+
+```javascript
+/*=========================================================================
+
+  Site behavior for GeoBrad.dev.
+
+  Loaded by index.html only. resume.html and privacy.html are standalone.
+
+  Every block below has a matching element in index.html. Adding code here
+  that targets an element the markup does not contain recreates issue #16,
+  where 664 lines sat dead in the tree for two years.
+
+=========================================================================*/
+
+$(function () {
+    "use strict";
+
+    var allWindow = $(window),
+        navBar = $(".nav-wrapper"),
+        scrollUp = $(".scroll-up"),
+        navList = navBar.find("ul.navbar-nav"),
+        sections = $(".one-page-section"),
+        skillsSection = $(".skills-section"),
+        skillLines = $(".progress-bar-line"),
+        motionQuery = window.matchMedia
+            ? window.matchMedia("(prefers-reduced-motion: reduce)")
+            : null,
+        scrollPos = 0;
+
+    // The navbar is position: fixed, so anything that scrolls to a section
+    // has to clear it or the heading lands underneath.
+    function navHeight() {
+        return navBar.outerHeight() || 0;
+    }
+
+    // Honor the OS setting rather than animating over someone who asked us
+    // not to. Read at call time, not at load, since the setting can change.
+    function duration(speed) {
+        return motionQuery && motionQuery.matches ? 0 : speed;
+    }
+
+/*------------------------------------------------
+  Preloader
+--------------------------------------------------*/
+
+    allWindow.on("load", function () {
+        $(".loader-con").fadeOut("slow");
+    });
+
+/*------------------------------------------------
+  Sticky navigation and scroll-to-top visibility
+--------------------------------------------------*/
+
+    function stickyNav() {
+        navBar.toggleClass("nav-sticky", scrollPos >= 100);
+        scrollUp.toggleClass("show-up-btn", scrollPos >= 1000);
+    }
+
+/*------------------------------------------------
+  Smooth scrolling for on-page anchors
+--------------------------------------------------*/
+
+    $("a.scroll").on("click", function (event) {
+        if (location.pathname.replace(/^\//, "") !== this.pathname.replace(/^\//, "") ||
+            location.hostname !== this.hostname) {
+            return;
+        }
+
+        var target = $(this.hash);
+        if (!target.length) {
+            target = $("[name=" + this.hash.slice(1) + "]");
+        }
+        if (!target.length) {
+            return;
+        }
+
+        event.preventDefault();
+        $("html, body").animate({
+            scrollTop: Math.max(0, target.offset().top - navHeight())
+        }, duration($(this).data("speed") || 800));
+    });
+
+    scrollUp.on("click", function (event) {
+        event.preventDefault();
+        $("html, body").animate({ scrollTop: 0 }, duration(900));
+    });
+
+/*------------------------------------------------
+  Close the mobile dropdown after tapping a link
+--------------------------------------------------*/
+
+    // Bootstrap 3 returns early from hide() when the element lacks .in, so
+    // this is a no-op on desktop where CSS keeps the menu expanded.
+    navBar.find(".navbar-collapse a").on("click", function () {
+        navBar.find(".navbar-collapse").collapse("hide");
+    });
+
+/*------------------------------------------------
+  Highlight the nav link for the visible section
+--------------------------------------------------*/
+
+    function changeActiveNavLink() {
+        var probe = scrollPos + navHeight();
+
+        sections.each(function () {
+            var section = $(this),
+                sectionTop = section.offset().top;
+
+            if (probe < sectionTop || probe > sectionTop + section.height()) {
+                return;
+            }
+
+            navList.find("a").removeClass("active");
+            navList.find('[href="#' + section.attr("id") + '"]').addClass("active");
+        });
+    }
+
+/*------------------------------------------------
+  Skill bars, animated once when scrolled into view
+--------------------------------------------------*/
+
+    function progressBars() {
+        if (!skillsSection.length || skillsSection.hasClass("done")) {
+            return;
+        }
+
+        var trigger = skillsSection.offset().top - (allWindow.height() - 160);
+        if (scrollPos < trigger) {
+            return;
+        }
+
+        skillsSection.addClass("done");
+        skillLines.each(function () {
+            var line = $(this),
+                percent = parseInt(line.attr("data-percent"), 10);
+
+            if (!isNaN(percent)) {
+                line.css("width", percent + "%");
+            }
+        });
+    }
+
+/*------------------------------------------------
+  One scroll handler drives all three
+--------------------------------------------------*/
+
+    function scrollFunctions() {
+        scrollPos = allWindow.scrollTop();
+        stickyNav();
+        changeActiveNavLink();
+        progressBars();
+    }
+
+    allWindow.on("scroll", scrollFunctions);
+
+    // Run once so a reload partway down the page, or a deep link, starts in
+    // the right state instead of waiting for the first scroll event.
+    scrollFunctions();
+
+});
+```
+
+- [ ] **Step 2: Syntax-check it**
+
+Run: `node --check js/main.js && echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Run the checker**
+
+Run: `python3 tools/verify_interactivity.py; echo "exit=$?"`
+
+Expected: still `exit=1`, but every `js/main.js still references ...` failure is gone. The remaining failures are all `index.html` ones, which Task 3 fixes.
+
+---
+
+### Task 3: Wire up index.html (green, markup side)
+
+**Files:**
+- Modify: `index.html:87` (drop `parallax`), `index.html:190,200,210` (skill bars), `index.html:325` (`#portfolio`), `index.html:467-468` (script tag), `index.html:561-570` (card handler)
+
+**Interfaces:**
+- Consumes: the DOM contract from Task 2.
+
+- [ ] **Step 1: Drop the parallax class from the hero**
+
+`index.html:87`, from:
+
+```html
+<section id="home" class="home-1 parallax one-page-section">
+```
+
+to:
+
+```html
+<section id="home" class="home-1 one-page-section">
+```
+
+- [ ] **Step 2: Give the three skill bars a data-percent and remove the inline width**
+
+`index.html:190`, from `<div class="progress-bar-line main-color-bg" style="width: 90%;"></div>`
+to `<div class="progress-bar-line main-color-bg" data-percent="90"></div>`
+
+`index.html:200`, from `<div class="progress-bar-line main-color-bg" style="width: 75%;"></div>`
+to `<div class="progress-bar-line main-color-bg" data-percent="75"></div>`
+
+`index.html:210`, from `<div class="progress-bar-line main-color-bg" style="width: 75%;"></div>`
+to `<div class="progress-bar-line main-color-bg" data-percent="75"></div>`
+
+- [ ] **Step 3: Let the portfolio section take part in nav highlighting**
+
+`index.html:325`, from:
+
+```html
+<section id="portfolio" class="section">
+```
+
+to:
+
+```html
+<section id="portfolio" class="section one-page-section">
+```
+
+- [ ] **Step 4: Load main.js**
+
+`index.html:467`, after the isotope tag and before the inline `<script>`:
+
+```html
+<!-- jQuery Filterizr JS -->
+<script src="js/isotope.pkgd.min.js"></script>
+<!-- Site behavior -->
+<script src="js/main.js"></script>
+<!-- Custom js -->
+<script>
+```
+
+- [ ] **Step 5: Stop the card handler from opening a second tab**
+
+`index.html:561-570`, from:
+
+```javascript
+            // Add click handlers for the cards
+            document.querySelectorAll('.portfolio-card').forEach((card, index) => {
+                const repo = portfolioRepos[index];
+                card.addEventListener('click', () => {
+                    if (repo.homepage) {
+                        window.open(repo.homepage, '_blank');
+                    } else {
+                        window.open(repo.html_url, '_blank');
+                    }
+                });
+            });
+```
+
+to:
+
+```javascript
+            // Make the whole card clickable, but let the real anchors inside
+            // it handle their own clicks. Without the guard, clicking "Live
+            // Demo" or "Code" opens the link and then bubbles up here, which
+            // opens a second tab.
+            document.querySelectorAll('.portfolio-card').forEach((card, index) => {
+                const repo = portfolioRepos[index];
+                card.addEventListener('click', (event) => {
+                    if (event.target.closest('a')) return;
+                    window.open(repo.homepage || repo.html_url, '_blank', 'noopener');
+                });
+            });
+```
+
+- [ ] **Step 6: Run the checker**
+
+Run: `python3 tools/verify_interactivity.py; echo "exit=$?"`
+Expected: `PASS: site interactivity is wired up` and `exit=0`.
+
+---
+
+### Task 4: Make the scroll-to-top button genuinely hidden
+
+`.scroll-up` is `opacity: 0` with no `pointer-events` or `visibility`, so it is an invisible but clickable and tab-focusable target parked in the bottom-right corner at all times. The acceptance criterion is "the scroll-to-top button appears and works"; a button that is always clickable but never visible does not meet it.
+
+**Files:**
+- Modify: `css/style.css:1199-1226`
+
+- [ ] **Step 1: Hide it properly and transition it in**
+
+`css/style.css:1199`, from:
+
+```css
+.scroll-up {
+    position: fixed;
+    font-size: 28px;
+    width: 46px;
+    height: 46px;
+    text-align: center;
+    line-height: 38px;
+    color: #fafafa;
+    border: 2px solid #333;
+    background-color: #333;
+    bottom: 25px;
+    right: 30px;
+    opacity: 0;
+    z-index: 60;
+}
+```
+
+to:
+
+```css
+.scroll-up {
+    position: fixed;
+    font-size: 28px;
+    width: 46px;
+    height: 46px;
+    text-align: center;
+    line-height: 38px;
+    color: #fafafa;
+    border: 2px solid #333;
+    background-color: #333;
+    bottom: 25px;
+    right: 30px;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    -webkit-transition: opacity .3s ease, visibility .3s ease;
+    -o-transition: opacity .3s ease, visibility .3s ease;
+    -moz-transition: opacity .3s ease, visibility .3s ease;
+    transition: opacity .3s ease, visibility .3s ease;
+    z-index: 60;
+}
+```
+
+`css/style.css:1224`, from:
+
+```css
+.show-up-btn {
+    opacity: 1;
+}
+```
+
+to:
+
+```css
+.show-up-btn {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+```
+
+- [ ] **Step 2: Confirm nothing else regressed**
+
+Run: `python3 tools/verify_interactivity.py; echo "exit=$?"`
+Expected: `exit=0`.
+
+---
+
+### Task 5: Reconcile CLAUDE.md
+
+`CLAUDE.md` carries a standing warning that `js/main.js` is not loaded. That becomes false the moment Task 3 lands, and the line numbers it cites all move.
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+Note: `CLAUDE.md` is currently untracked because `.gitignore:120` (`/C*.md`) matches it. That is issue #23 and is out of scope here. Edit the file regardless; whether it can be committed is issue #23's problem, and the PR body should say so.
+
+- [ ] **Step 1: Delete the "js/main.js is not loaded" section**
+
+Remove the whole `### js/main.js is not loaded` block, including the sentence pointing at issue #16.
+
+- [ ] **Step 2: Replace it with what is true now**
+
+```markdown
+### js/main.js
+
+Loaded by `index.html` only; `resume.html` and `privacy.html` are standalone.
+It drives the sticky navbar, on-page smooth scrolling, active-link tracking,
+mobile nav collapse, the scroll-to-top button, and the skill bars.
+
+Everything in it has a matching element in `index.html`. That is the rule the
+file exists to keep: it once held 664 lines, of which roughly 500 targeted
+elements no page contained, and the whole file went unloaded for two years
+without anyone noticing (issue #16). Do not add a block here without an
+element that uses it, and run `python3 tools/verify_interactivity.py` after
+touching `js/main.js` or the markup it depends on.
+
+Skill bar widths come from `data-percent` on `.progress-bar-line`, not from
+inline styles. CSS starts the bars at 5% (`css/style.css:716`) and JavaScript
+animates them to the target once the section scrolls into view. With
+JavaScript disabled the bars stay at 5%; that is accepted, since the portfolio
+section already requires JavaScript.
+
+The hero has no parallax. `.home-1` uses `background-size: cover`, so shifting
+`backgroundPosition` slides the image down and exposes blank space under the
+overlay. The old `parallax()` function and the `parallax` class were removed
+together.
+```
+
+- [ ] **Step 3: Add the checker to the Development Workflow section**
+
+Under "Testing Locally", add:
+
+```markdown
+### Verifying site interactivity
+
+```bash
+python3 tools/verify_interactivity.py
+```
+
+Exits 0 when the issue #16 wiring still holds: `index.html` loads `js/main.js`
+after jQuery, every section a nav link points at carries `one-page-section`,
+every skill bar has a `data-percent` and no inline width, the portfolio card
+click handler yields to real anchors, and `js/main.js` references nothing the
+markup lacks. Standard library only; it syntax-checks `js/main.js` with `node`
+when node happens to be installed, and skips that check otherwise. Run it
+after touching `js/main.js`, `index.html`, or the nav markup.
+```
+
+- [ ] **Step 4: Fix the stale line references elsewhere in CLAUDE.md**
+
+The "Site Structure" and "Key Features & Architecture" sections cite
+`js/main.js:140-157`, `:159-184`, `:212-236`, `:61-132`, `:246-268`,
+`:278-304`, `:321-411`. All of those are wrong after Task 2. Replace them with
+function names rather than line numbers, since line numbers go stale:
+`stickyNav()`, the `a.scroll` click handler, `changeActiveNavLink()`,
+`progressBars()`. Delete the parallax and commented-out-contact-form bullets;
+neither exists anymore.
+
+---
+
+## Verification
+
+Automated, run from the repo root:
+
+```bash
+python3 tools/verify_interactivity.py   # expect: PASS, exit 0
+node --check js/main.js                 # expect: silent, exit 0
+```
+
+Live drive (Phase 6, High tier, so failure and edge paths too). Serve the site
+and exercise every acceptance criterion in a real browser:
+
+```bash
+python3 -m http.server 8765
+```
+
+| Criterion | How to prove it |
+|---|---|
+| Navbar goes sticky past 100px | Load at top, confirm `.nav-wrapper` has no `nav-sticky`. Scroll to 150, confirm it does and the background turns white. Scroll back to 50, confirm it comes off. |
+| Nav links smooth-scroll | Click each of HOME, ABOUT, SERVICES, PORTFOLIO, CONTACT. Confirm `scrollY` animates rather than jumping, and the section heading lands below the navbar, not under it. |
+| `data-speed` still honored | CONTACT (1700ms) visibly takes longer than HOME (800ms). |
+| Active link tracks the section, including PORTFOLIO | Scroll through the page and confirm `.active` moves across all five links, PORTFOLIO included. |
+| Mobile nav closes after tapping | Resize to 375px wide, open the toggle, tap ABOUT, confirm `.navbar-collapse` loses `.in`. |
+| Scroll-to-top appears and works | Below 1000px of scroll, confirm `.scroll-up` has no `show-up-btn` and `elementFromPoint` at its corner is not the button. Past 1000, confirm it is visible, then click it and confirm `scrollY` returns to 0. |
+| Skill bars animate | Load at top, confirm the three bars read 5%. Scroll to About, confirm they settle at 90%, 75%, 75%. |
+| Card opens exactly one tab | Patch `window.open` to count calls. Click a card body: 1 call. Click "Code": 0 `window.open` calls, the anchor handles it. Click "Live Demo" where present: same. |
+| No console errors | Collect console messages across the whole drive. Expect zero errors. A GitHub API rate-limit message is a network condition, not a regression; note it if it appears. |
+| Failure path: GitHub API down | Block `api.github.com`, reload, confirm the loader still hides, the error copy renders, and nav, sticky, skill bars, and scroll-to-top all still work. This matters because the loader is hidden by the portfolio script's `finally`, not by `main.js`. |
+| Edge path: reduced motion | Emulate `prefers-reduced-motion: reduce`, click a nav link, confirm it jumps instantly instead of animating. |
+| Edge path: deep link | Load `index.html#contact` directly, confirm the navbar is already sticky and CONTACT is already active without needing a scroll event. |

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 <!-- END MAIN NAVIGATION BAR -->
 
 <!-- HOME -->
-<section id="home" class="home-1 parallax one-page-section">
+<section id="home" class="home-1 one-page-section">
     <div class="page-table">
         <div class="table-cell text-center">
             <div class="avatar-hero">
@@ -187,7 +187,7 @@
                         <span class="main-color progress-bar-level">Expert</span>
                     </div>
                     <div class="progress-bar-skills">
-                        <div class="progress-bar-line main-color-bg" style="width: 90%;"></div>
+                        <div class="progress-bar-line main-color-bg" data-percent="90"></div>
                     </div>
                 </div>
 
@@ -197,7 +197,7 @@
                         <span class="main-color progress-bar-level">Advanced</span>
                     </div>
                     <div class="progress-bar-skills">
-                        <div class="progress-bar-line main-color-bg" style="width: 75%;"></div>
+                        <div class="progress-bar-line main-color-bg" data-percent="75"></div>
                     </div>
                 </div>
 
@@ -207,7 +207,7 @@
                         <span class="main-color progress-bar-level">Advanced</span>
                     </div>
                     <div class="progress-bar-skills">
-                        <div class="progress-bar-line main-color-bg" style="width: 75%;"></div>
+                        <div class="progress-bar-line main-color-bg" data-percent="75"></div>
                     </div>
                 </div>
 
@@ -322,7 +322,7 @@
 <!-- END SERVICES -->
 
 <!-- portfolio -->
-<section id="portfolio" class="section">
+<section id="portfolio" class="section one-page-section">
     <div class="container">
         <div class="section-title">
             <h2>Portfolio</h2>
@@ -465,6 +465,8 @@
 <script src="js/imagesloaded.pkgd.min.js"></script>
 <!-- jQuery Filterizr JS -->
 <script src="js/isotope.pkgd.min.js"></script>
+<!-- Site behavior -->
+<script src="js/main.js"></script>
 <!-- Custom js -->
 <script>
     // Keep the footer year current so it never goes stale. Runs before the
@@ -557,15 +559,15 @@
                 portfolioContainer.appendChild(card);
             });
 
-            // Add click handlers for the cards
+            // Make the whole card clickable, but let the real anchors inside
+            // it handle their own clicks. Without the guard, clicking "Live
+            // Demo" or "Code" opens the link and then bubbles up here, which
+            // opens a second tab.
             document.querySelectorAll('.portfolio-card').forEach((card, index) => {
                 const repo = portfolioRepos[index];
-                card.addEventListener('click', () => {
-                    if (repo.homepage) {
-                        window.open(repo.homepage, '_blank');
-                    } else {
-                        window.open(repo.html_url, '_blank');
-                    }
+                card.addEventListener('click', (event) => {
+                    if (event.target.closest('a')) return;
+                    window.open(repo.homepage || repo.html_url, '_blank', 'noopener');
                 });
             });
 
@@ -746,7 +748,13 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.7);    opacity: 0;
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 0;
+    /* The overlay covers the whole card at z-index 3, above the content at
+       z-index 2. An opacity: 0 element is still hit-testable, so without this
+       it swallows every click and the Live Demo and Code anchors underneath
+       can never be reached. */
+    pointer-events: none;
     transition: all 0.4s ease;
     z-index: 3;
     display: flex;

--- a/js/main.js
+++ b/js/main.js
@@ -1,665 +1,184 @@
 /*=========================================================================
 
-Template Name: IMOZAR - Personal Portfolio Template
-Author: PhyDev
-Author Link: https://themeforest.net/user/phydev;
-Version: 1.0
-Design and Developed by: PhyDev
+  Site behavior for GeoBrad.dev.
 
-NOTE: This is the main javascript file for the template
+  Loaded by index.html only. resume.html and privacy.html are standalone.
+
+  Every block below has a matching element in index.html. Adding code here
+  that targets an element the markup does not contain recreates issue #16,
+  where 664 lines sat dead in the tree for two years.
 
 =========================================================================*/
 
-$(function(){
-"use strict";
+$(function () {
+    "use strict";
 
-  	// Define Some Elements
-  	var allWindow = $(window),
-        body = $('body'),
-        top = allWindow.scrollTop(),
-        navBar = $(".nav-wrapper");
+    var allWindow = $(window),
+        navBar = $(".nav-wrapper"),
+        scrollUp = $(".scroll-up"),
+        navList = navBar.find("ul.navbar-nav"),
+        sections = $(".one-page-section"),
+        skillsSection = $(".skills-section"),
+        skillLines = $(".progress-bar-line"),
+        motionQuery = window.matchMedia
+            ? window.matchMedia("(prefers-reduced-motion: reduce)")
+            : null,
+        scrollPos = 0;
+
+    // The navbar is position: fixed, so anything that scrolls to a section
+    // has to clear it or the heading lands underneath.
+    //
+    // Below the Bootstrap breakpoint an open dropdown is in flow inside the
+    // fixed header, which measures 278px against the 63px it collapses back
+    // to. Since every caller here is about to close that menu, subtract it.
+    function navHeight() {
+        var collapse = navBar.find(".navbar-collapse"),
+            height = navBar.outerHeight() || 0;
+
+        if (collapse.hasClass("in")) {
+            height -= collapse.outerHeight() || 0;
+        }
+
+        return height;
+    }
+
+    // Honor the OS setting rather than animating over someone who asked us
+    // not to. Read at call time, not at load, since the setting can change.
+    function duration(speed) {
+        return motionQuery && motionQuery.matches ? 0 : speed;
+    }
 
 /*------------------------------------------------
-  Javascript Function for The Preloader
+  Preloader
 --------------------------------------------------*/
 
-    allWindow.on("load", function() {
-        $('.loader-con').fadeOut('slow');
+    allWindow.on("load", function () {
+        $(".loader-con").fadeOut("slow");
     });
 
+/*------------------------------------------------
+  Sticky navigation and scroll-to-top visibility
+--------------------------------------------------*/
 
-/*-----------------------------------------------------
-  Javascript Function To check Aniamtion support
--------------------------------------------------------*/
-
-    var animation = false,
-    animationstring = 'animation',
-    keyframeprefix = '',
-    domPrefixes = 'Webkit Moz O ms Khtml'.split(' '),
-    pfx  = '',
-    elm = document.createElement('div');
-
-    if( elm.style.animationName !== undefined ) { animation = true; }
-
-    if( animation === false ) {
-      for( var i = 0; i < domPrefixes.length; i++ ) {
-        if( elm.style[ domPrefixes[i] + 'AnimationName' ] !== undefined ) {
-          pfx = domPrefixes[ i ];
-          animationstring = pfx + 'Animation';
-          keyframeprefix = '-' + pfx.toLowerCase() + '-';
-          animation = true;
-          break;
-        }
-      }
+    function stickyNav() {
+        navBar.toggleClass("nav-sticky", scrollPos >= 100);
+        scrollUp.toggleClass("show-up-btn", scrollPos >= 1000);
     }
 
+/*------------------------------------------------
+  Smooth scrolling for on-page anchors
+--------------------------------------------------*/
 
-/*-----------------------------------------------------
-  Javascript Function For Smooth Mouse Scrolling
--------------------------------------------------------*/
-
-    jQuery.scrollSpeed = function(step, speed) {
-        
-        var $document = $(document),
-            $body = $('html, body'),
-            option = 'default',
-            root = top,
-            scroll = false,
-            scrollY,
-            view;
-            
-        if (window.navigator.msPointerEnabled) {
-            return false;
+    $("a.scroll").on("click", function (event) {
+        if (location.pathname.replace(/^\//, "") !== this.pathname.replace(/^\//, "") ||
+            location.hostname !== this.hostname) {
+            return;
         }
-            
-		jQuery.event.special.mousewheel = {
-			setup: function( _, ns, handle ){
-				if ( ns.includes("PreventDefault") ) {
-				 	this.addEventListener("mousewheel", handle, { passive: false });
-				} else {
-					return false;
-				}
-			}
-		}
 
-        allWindow.on('mousewheel.PreventDefault DOMMouseScroll', function(e) {
-            
-            var deltaY = e.originalEvent.wheelDeltaY,
-                detail = e.originalEvent.detail;
-                scrollY = $document.height() > allWindow.height();
-                scroll = true;
-            
-            if (scrollY) {
-                
-                view = allWindow.height();
-                    
-                if (deltaY < 0 || detail > 0) {
-                    root = (root + view) >= $document.height() ? root : root += step;
-                }
-                
-                if (deltaY > 0 || detail < 0) {
-                    root = root <= 0 ? 0 : root -= step;
-                }
-                
-                $body.stop().animate({
-                    scrollTop: root
-                }, speed, option, function() {
-                    scroll = false;
-                });
-            }
-            
-            return false;
-            
-        }).on('scroll', function() {
-            
-            if (scrollY && !scroll) root = top;
-            if (!scroll) root = allWindow.scrollTop();
-            
-        }).on('resize', function() {
-            
-            if (scrollY && !scroll) view = allWindow.height();
-            
-        });       
-    };
-    
-    jQuery.easing.default = function (x,t,b,c,d) {
-        return -c * ((t=t/d-1)*t*t*t - 1) + b;
-    };
-
-    // initialize Smooth Scrolling Only in Modern browsers
-    if(animation) {
-    	jQuery.scrollSpeed(50, 500);
-    }
-
-
-/*---------------------------------------------------------------------
-  Javascript Function For Sticky Navigation Bar AND SMOOTH SCROLLING
-----------------------------------------------------------------------*/
-
-    // Define stikyNav Function
-    function stikyNav() {
-
-      top = allWindow.scrollTop();
-
-      if ( top >= 100 ) {
-        navBar.addClass("nav-sticky");
-
-      } else {
-        navBar.removeClass("nav-sticky");
-      }
-
-      // SHow Also Scroll up Button
-      if ( top >= 1000 ) {
-        $('.scroll-up').addClass("show-up-btn");
-      } else {
-        $('.scroll-up').removeClass("show-up-btn");
-      }
-    }
-
-    // Select all links with hashes
-    $('a.scroll').on('click', function(event) {
-        // On-page links
-        if ( location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '') && location.hostname === this.hostname ) {
-          // Figure out element to scroll to
-          var target = $(this.hash),
-              speed= $(this).data("speed") || 800;
-              target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
-
-          // Does a scroll target exist?
-          if (target.length) {
-            // Only prevent default if animation is actually gonna happen
-            event.preventDefault();
-            $('html, body').animate({
-              scrollTop: target.offset().top
-            }, speed);
-          }
+        var target = $(this.hash);
+        if (!target.length) {
+            target = $("[name=" + this.hash.slice(1) + "]");
         }
+        if (!target.length) {
+            return;
+        }
+
+        event.preventDefault();
+        $("html, body").animate({
+            scrollTop: Math.max(0, target.offset().top - navHeight())
+        }, duration($(this).data("speed") || 800));
     });
 
-    $(".scroll-up").on('click', function (e) {
-      e.preventDefault();
-      $('html, body').animate({
-        scrollTop: 0
-      }, 900);
-    });
-    
-
-/*---------------------------------------------------------------------
-  Javascript Function for Hide Navbar Dropdown After Click On Links
--------------------------------------------------------------------*/
-
-    var navLinks = navBar.find(".navbar-collapse ul li a");
-
-    $.each( navLinks, function( i, val ) {
-
-      var navLink = $(this);
-
-        navLink.on('click', function (e) {
-          navBar.find(".navbar-collapse").collapse('hide');
-        });
-
+    scrollUp.on("click", function (event) {
+        event.preventDefault();
+        $("html, body").animate({ scrollTop: 0 }, duration(900));
     });
 
+/*------------------------------------------------
+  Close the mobile dropdown after tapping a link
+--------------------------------------------------*/
 
-/*----------------------------------------------------------------
-  Javascript Function For Change active Class on navigation bar
------------------------------------------------------------------*/
+    // Bootstrap 3 returns early from hide() when the element lacks .in, so
+    // this is a no-op on desktop where CSS keeps the menu expanded.
+    navBar.find(".navbar-collapse a").on("click", function () {
+        navBar.find(".navbar-collapse").collapse("hide");
+    });
 
-    var sections = $('.one-page-section'),
-        navList = navBar.find("ul.navbar-nav");
+/*------------------------------------------------
+  Highlight the nav link for the visible section
+--------------------------------------------------*/
 
-    // Define ChangeClass Function
-    function ChangeClass() {
+    function changeActiveNavLink() {
+        var probe = scrollPos + navHeight();
 
-      top = allWindow.scrollTop();
+        sections.each(function () {
+            var section = $(this),
+                sectionTop = section.offset().top;
 
-        $.each(sections, function(i,val) {
-
-          var section = $(this),
-              section_top = section.offset().top,
-              bottom = section_top + section.height();
-
-            if (top >= section_top && top <= bottom) {
-
-              var naItems = navList.find('li');
-
-              $.each(naItems ,function(i,val) {
-                var item = $(this);
-                item.find("a").removeClass("active");
-              });
-
-              navList.find('li [href="#' + section.attr('id') + '"]').addClass('active');
+            if (probe < sectionTop || probe > sectionTop + section.height()) {
+                return;
             }
 
+            navList.find("a").removeClass("active");
+            navList.find('[href="#' + section.attr("id") + '"]').addClass("active");
         });
+    }
 
-    } // End of ChangeClass Function
+/*------------------------------------------------
+  Skill bars, animated once when scrolled into view
+--------------------------------------------------*/
 
-
-/*---------------------------------------------------
-  Javascript Function FOR PARALLAX EFFECT
----------------------------------------------------*/
-
-    // create variables
-    var backgrounds = $('.parallax');
-
-    function parallax() {
-
-      // for each of background parallax element
-      $.each( backgrounds, function( i, val ) {
-
-        var backgroundObj = $(this),
-          backgroundObjTop = backgroundObj.offset().top,
-          backgroundHeight = backgroundObj.height();
-
-        // update positions
-        top = allWindow.scrollTop();
-
-          var yPos = ((top - backgroundObjTop))/2;
-
-          if ( yPos <= backgroundHeight + backgroundObjTop ) {
-            backgroundObj.css({
-              backgroundPosition: '50% ' + yPos + 'px'
-            });
-          }
-
-      });
-    };
-
-
-/*-----------------------------------------------------------------
-  Javascript Function for PROGRESS BAR LINES  SCRIPT
-------------------------------------------------------------------*/
-
-    var linesHead = $(".skills-section"),
-        line = $(".progress-bar-line");
-        
-    //Progress Bars function
-    function progressFunction(e) {
-
-      if ( linesHead.length ) {
-
-        if (!linesHead.hasClass("done")) {
-
-          var linesHeadTop = linesHead.offset().top,
-              top = allWindow.scrollTop(),
-              winH = allWindow.height() - 160;
-
-          if (top >= linesHeadTop - winH) {
-
-            linesHead.addClass("done");
-            $.each( line, function( i, val ) {
-
-            var thisLine = $(this),
-              value = thisLine.data("percent"),
-              progressCont = $(thisLine).closest('.progress-bar-linear').find(".progress-cont span");
-
-              thisLine.css("width",value + "%");
-              progressCont.html(value + "%")
-
-            });
-          }
+    function progressBars() {
+        if (!skillsSection.length || skillsSection.hasClass("done")) {
+            return;
         }
-      }
-    } //End progressFunction Fuction
 
+        var trigger = skillsSection.offset().top - (allWindow.height() - 160);
+        if (scrollPos < trigger) {
+            return;
+        }
+
+        skillsSection.addClass("done");
+        skillLines.each(function () {
+            var line = $(this),
+                percent = parseInt(line.attr("data-percent"), 10);
+
+            if (!isNaN(percent)) {
+                line.css("width", percent + "%");
+            }
+        });
+    }
+
+/*------------------------------------------------
+  One scroll handler drives all three
+--------------------------------------------------*/
 
     function scrollFunctions() {
-      stikyNav();
-      ChangeClass();
-      parallax();
-      progressFunction();
+        scrollPos = allWindow.scrollTop();
+        stickyNav();
+        changeActiveNavLink();
+        progressBars();
     }
 
-    // add Event listener to window
-    allWindow.on('scroll', function() {
-      scrollFunctions();
-    });
+    // One pass per frame. The three functions above interleave class writes
+    // with about a dozen offset and height reads, and native scrolling fires
+    // far more often than once a frame now that the old wheel-event hijack is
+    // gone, so running them unthrottled thrashes layout on every event.
+    var pending = false;
 
-
-/*------------------------------------------
-  Javascript for initialize text Typer
---------------------------------------------*/
-
-    // initialize text Typer Only in Modern browsers
-    // if (animation) {
-    //
-    //   var text = $('#home .typer-title'),
-    //       textOne = "i'm ui/ux designer",
-    //       textTwo = "let's work together",
-    //       textThree = "i can create awesome stuff";
-    //
-    //       if (!!$.prototype.typer) {
-    //         text.typer([textOne,textTwo,textThree]);
-    //       }
-    // }
-
-
-/*----------------------------------------------------------------------
- Javascript Function Initialize Particules
------------------------------------------------------------------------*/
-
-    if ( typeof particlesJS !== "undefined") {
-
-      particlesJS('particles-js', {
-          "particles": {
-            "number": {
-              "value": 80,
-              "density": {
-                "enable": true,
-                "value_area": 600
-              }
-            },
-            "color": {
-              "value": '#777',
-            },
-            "shape": {
-              "type": "circle",
-              "stroke": {
-                "width": 0,
-                "color": "#888"
-              },
-              "polygon": {
-                "nb_sides": 5
-              },
-              "image": {
-                "src": "img/github.svg",
-                "width": 100,
-                "height": 100
-              }
-            },
-            "opacity": {
-              "value": 0.7,
-              "random": false,
-              "anim": {
-                "enable": false,
-                "speed": 1,
-                "opacity_min": 0.1,
-                "sync": false
-              }
-            },
-            "size": {
-              "value": 4,
-              "random": true,
-              "anim": {
-                "enable": false,
-                "speed": 40,
-                "size_min": 0.1,
-                "sync": false
-              }
-            },
-            "line_linked": {
-              "enable": true,
-              "distance": 150,
-              "color": "#bbb",
-              "opacity": 0.4,
-              "width": 1
-            },
-            "move": {
-              "enable": true,
-              "speed": 4,
-              "direction": "bottom",
-              "random": false,
-              "straight": false,
-              "out_mode": "out",
-              "attract": {
-                "enable": false,
-                "rotateX": 600,
-                "rotateY": 1200
-              }
-            }
-          },
-          "interactivity": {
-            "detect_on": "canvas",
-            "events": {
-              "onhover": {
-                "enable": true,
-                "mode": "repulse"
-              },
-              "onclick": {
-                "enable": true,
-                "mode": "push"
-              },
-              "resize": true
-            },
-            "modes": {
-              "grab": {
-                "distance": 400,
-                "line_linked": {
-                  "opacity": 1
-                }
-              },
-              "bubble": {
-                "distance": 400,
-                "size": 40,
-                "duration": 2,
-                "opacity": 8,
-                "speed": 3
-              },
-              "repulse": {
-                "distance": 200
-              },
-              "push": {
-                "particles_nb": 4
-              },
-              "remove": {
-                "particles_nb": 2
-              }
-            }
-          },
-          "retina_detect": true,
-          "config_demo": {
-            "hide_card": false,
-            "background_color": "#b61924",
-            "background_image": "",
-            "background_position": "50% 50%",
-            "background_repeat": "no-repeat",
-            "background_size": "cover"
-          }
-        });
-    }
-
-
-/*------------------------------------------------------
-  Javascript Function for filtering portfolio items
---------------------------------------------------------*/
-
-  var FilterContainer = $('#work .filtr-container');
-
-  if ( FilterContainer.length > 0 && !!$.prototype.isotope ) {
-  
-    var filterizd;
-    FilterContainer.imagesLoaded( function() {
-      filterizd = FilterContainer.isotope({
-        itemSelector: '.filtr-item',
-      });
-    });
-    
-    $('#work-list li a.filter').on( 'click', function(e) {
-
-        // Prevent the default link behavior 
-        e.preventDefault();
-        
-        var target = $(this),
-            filterValue = target.data('filter');
-
-        filterizd.isotope({ filter: filterValue });
-
-        // return if already current
-        if (!target.hasClass("filter-active")) {
-          // remove current
-          $('#work-list').find('.filter-active').removeClass('filter-active');
-          // set current
-          target.addClass('filter-active');
+    allWindow.on("scroll", function () {
+        if (pending) {
+            return;
         }
-
+        pending = true;
+        window.requestAnimationFrame(function () {
+            pending = false;
+            scrollFunctions();
+        });
     });
 
-  }
-
-
-/*-------------------------------------------
- Magnific Popup Portfolio Initializing
--------------------------------------------*/
-
-    $(".popup-youtube").magnificPopup({
-        type: 'iframe'
-    });
-
-    $('.popup-link').magnificPopup({
-      type: 'image',
-      removalDelay: 300,
-      mainClass: 'mfp-fade',
-      gallery:{
-          enabled:true
-      },
-      zoom: {
-        enabled: true,
-        duration: 260,
-        easing: 'ease-in',
-      },
-      image: {
-          titleSrc: function(item){
-            let title = item.el.attr('title');
-
-            if(item.el.data('url')) {
-              return '<a href="'+ item.el.data('url') +'" target="_blank">'+ title +'</a>';
-            }
-
-            return title;
-          }
-      }
-    });
-
-
-/*------------------------------------------------------
-Javascript Function for initialize owl carousel
---------------------------------------------------------*/
-
-    if (!!$.prototype.owlCarousel) {
-
-      $(".home-3 .home-carousel").owlCarousel({
-        nav: true,
-        navText : [
-          "<div class='home-slider-btn effect ver-center'><i class='fa fa-chevron-left center'></i><span></span></div>",
-          "<div class='home-slider-btn effect ver-center'><i class='fa fa-chevron-right center'></i><span></span></div>"
-        ],
-        dots: true,
-        loop: true,
-        items: 1,
-      });
-
-      $(".testimonial-slider").owlCarousel({
-        loop: true,
-        nav: true,
-        navText : [
-          "<div class='testimonial-slider-btn effect hor-center'><i class='fa fa-angle-left center'></i></div>",
-          "<div class='testimonial-slider-btn effect hor-center'><i class='fa fa-angle-right center'></i></div>"
-        ],
-        margin: 20,
-        responsive : {
-            0 : {
-              items: 1,
-            },
-            780 : {
-              items: 2,
-            },
-          }
-      });
-
-    }
-
-
-/*------------------------------------------------------------------------
- Javascript Function for Validate and Submit the CONTACT Form Using AJAX
--------------------------------------------------------------------------*/
-
-    // Get the form.
-    // var form = $('#contact-form'),
-    //     reg = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{3,4})$/,
-    //     inputs = $(".input-field");
-    //
-    // function validateForm() {
-    //
-    //   if ($(this).is("#email")) {
-    //
-    //       var email = $(this).val(),
-    //           res = reg.test(email);
-    //
-    //       if (res) {
-    //         $(".email-error").html("");
-    //       } else {
-    //         $(".email-error").html("please enter a valid email.");
-    //         return false;
-    //       }
-    //
-    //   } else {
-    //
-    //       var target = ($(this).attr("id")),
-    //           targetMessage = $("."+target+"-error");
-    //
-    //       if ($(this).val() === "") {
-    //
-    //         targetMessage.html("please enter a valid "+target+".");
-    //         return false;
-    //
-    //       } else {
-    //         targetMessage.html(" ");
-    //       }
-    //
-    //   }
-    // } // End ValidateForm Function
-    //
-    // $.each(inputs, function( i, val ) {
-    //   $(this).on("blur", validateForm);
-    // });
-    //
-    // // Get the messages div.
-    // var formMessages = $('#form-message');
-    //
-    // // Set up an event listener for the contact form.
-    // $(form).on('submit',function(event) {
-    //
-    //   // Stop the browser from submitting the form.
-    //   event.preventDefault();
-    //
-    //   // Serialize the form data.
-    //   var formData = $(form).serialize();
-    //
-    //   // Submit the form using AJAX.
-    //   $.ajax({
-    //       type: 'POST',
-    //       url: form.attr('action'),
-    //       data: formData
-    //   }).done(function(response) {
-    //
-    //     // Make sure that the formMessages div has the 'success' class.
-    //     formMessages.removeClass('error');
-    //     formMessages.addClass('success');
-    //
-    //     // Set the message text.
-    //     formMessages.text(response);
-    //
-    //     // Clear the form.
-    //     $('#name').val('');
-    //     $('#email').val('');
-    //     $('#message').val('');
-    //
-    //   }).fail(function(data) {
-    //
-    //       // Make sure that the formMessages div has the 'error' class.
-    //       formMessages.removeClass('success');
-    //       formMessages.addClass('error');
-    //
-    //       // Set the message text.
-    //       if (data.responseText !== '') {
-    //           formMessages.text(data.responseText);
-    //       } else {
-    //           formMessages.text('Sorry! An error occured and your message could not be sent.');
-    //       }
-    //
-    //   });
-    // });
-
+    // Run once so a reload partway down the page, or a deep link, starts in
+    // the right state instead of waiting for the first scroll event.
+    scrollFunctions();
 
 });

--- a/tools/verify_interactivity.py
+++ b/tools/verify_interactivity.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Verify the site's interactive JavaScript is actually wired up.
+
+Standalone, standard library only, run by hand from the repo root:
+
+    python3 tools/verify_interactivity.py
+
+Exits 0 when the issue #16 acceptance criteria still hold at the source
+level: index.html loads js/main.js after jQuery, every section a nav link
+points at takes part in active-link tracking, every skill bar carries a
+data-percent instead of a hardcoded inline width, the portfolio card click
+handler yields to real anchors, and js/main.js references nothing the
+markup does not contain.
+
+Behavior (does the navbar actually go sticky, does the bar actually
+animate) cannot be checked here. Drive that in a browser.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX = ROOT / "index.html"
+MAIN_JS = ROOT / "js" / "main.js"
+STYLE_CSS = ROOT / "css" / "style.css"
+
+failures = []
+
+
+def fail(message):
+    failures.append(message)
+
+
+class IndexFacts(HTMLParser):
+    """Collect the few facts about index.html that the checks below need."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.scripts = []        # src of every <script src=...>
+        self.ids = {}            # id -> set of class tokens
+        self.nav_targets = []    # fragment of every <a class="scroll" href="#...">
+        self.progress_bars = []  # (data-percent, style) per .progress-bar-line
+        self.parallax = []       # tag name of every element with class "parallax"
+
+    def handle_starttag(self, tag, attrs):
+        attr = dict(attrs)
+        classes = set((attr.get("class") or "").split())
+
+        if tag == "script" and attr.get("src"):
+            self.scripts.append(attr["src"])
+
+        if attr.get("id"):
+            self.ids[attr["id"]] = classes
+
+        if tag == "a" and "scroll" in classes:
+            href = attr.get("href") or ""
+            if href.startswith("#") and len(href) > 1:
+                self.nav_targets.append(href[1:])
+
+        if "progress-bar-line" in classes:
+            self.progress_bars.append((attr.get("data-percent"), attr.get("style")))
+
+        if "parallax" in classes:
+            self.parallax.append(tag)
+
+
+def check_script_tag(facts):
+    """main.js has to load, and it has to load after jQuery."""
+    if "js/main.js" not in facts.scripts:
+        fail(
+            "index.html does not load js/main.js. The tag was dropped in "
+            "eba0f7b and every interaction in that file died with it."
+        )
+        return
+
+    jquery = [i for i, src in enumerate(facts.scripts) if "jquery.min.js" in src]
+    if not jquery:
+        fail("index.html loads js/main.js but not jQuery; main.js is jQuery code.")
+    elif facts.scripts.index("js/main.js") < jquery[0]:
+        fail("js/main.js is loaded before jQuery, so it throws on load.")
+
+
+def check_nav_targets(facts):
+    """ChangeClass() only sees sections carrying one-page-section."""
+    for target in facts.nav_targets:
+        classes = facts.ids.get(target)
+        if classes is None:
+            fail("A nav link points at #%s but no element has that id." % target)
+        elif "one-page-section" not in classes:
+            fail(
+                "#%s lacks the one-page-section class, so its nav link never "
+                "highlights." % target
+            )
+
+
+def check_progress_bars(facts):
+    """Bars animate from the CSS 5% default to data-percent."""
+    if not facts.progress_bars:
+        fail("No .progress-bar-line elements found in index.html.")
+
+    for value, style in facts.progress_bars:
+        if value is None:
+            fail(
+                "A .progress-bar-line has no data-percent, so main.js would "
+                "set its width to 'undefined%'."
+            )
+        elif not value.isdigit() or int(value) > 100:
+            fail("A .progress-bar-line has data-percent=%r, not an integer 0-100." % value)
+
+        if style and "width" in style:
+            fail(
+                "A .progress-bar-line still hardcodes width in its style "
+                "attribute (%r), which pins it at the final value." % style
+            )
+
+
+def check_card_handler(html):
+    """Clicking Live Demo or Code must not also fire the card handler."""
+    if "portfolio-card" not in html:
+        return
+    if "closest('a')" not in html and 'closest("a")' not in html:
+        fail(
+            "The portfolio card click handler does not bail out on anchor "
+            "clicks, so clicking Live Demo or Code opens two tabs."
+        )
+
+    # The guard above is only reachable if the anchors are. .portfolio-overlay
+    # covers the whole card at z-index 3 above the content's z-index 2, and an
+    # opacity: 0 element is still hit-testable, so without pointer-events: none
+    # every click lands on the overlay. That makes the Live Demo and Code links
+    # dead and the anchor guard permanently false.
+    rule = re.search(r"\.portfolio-overlay\s*\{(.*?)\}", html, re.S)
+    if rule is None:
+        fail("Could not find the .portfolio-overlay rule in index.html.")
+    elif not re.search(r"pointer-events\s*:\s*none", rule.group(1)):
+        fail(
+            ".portfolio-overlay has no 'pointer-events: none', so it swallows "
+            "every click on a card. The Live Demo and Code anchors are "
+            "unreachable and the card handler's anchor guard never fires."
+        )
+
+
+def check_scroll_up_transition(css):
+    """.scroll-up must not narrow the transition it inherits from .effect.
+
+    <a class="scroll-up effect"> gets 'transition: all .4s' from .effect. A
+    later, equal-specificity 'transition: opacity, visibility' on .scroll-up
+    wins on source order and silently drops the hover background and color
+    fade, so use 'all' and keep both.
+    """
+    rule = re.search(r"\.scroll-up\s*\{(.*?)\}", css, re.S)
+    if rule is None:
+        fail("Could not find the .scroll-up rule in css/style.css.")
+        return
+
+    declarations = re.findall(r"(?<![-\w])transition\s*:\s*([^;]+);", rule.group(1))
+    if not declarations:
+        return
+    if not all(value.strip().startswith("all") for value in declarations):
+        fail(
+            ".scroll-up declares a transition that does not use 'all', which "
+            "overrides .effect's 'transition: all .4s' and kills the hover "
+            "fade. Declared: %s" % "; ".join(v.strip() for v in declarations)
+        )
+
+
+def check_no_dead_code(facts, js):
+    """Nothing in main.js may target an element or library the page lacks."""
+    banned = [
+        ("magnificPopup", "no .popup-youtube or .popup-link element exists"),
+        ("owlCarousel", "no .home-carousel or .testimonial-slider element exists"),
+        ("isotope", "no '#work .filtr-container' element exists"),
+        ("imagesLoaded", "only the deleted isotope block used it"),
+        ("particlesJS", "index.html never loads js/particles.js"),
+        ("typer", "the typer initialization was deleted"),
+        ("scrollSpeed", "the mousewheel hijack was removed; it overrode native scrolling"),
+        ("mousewheel", "the mousewheel hijack was removed; it overrode native scrolling"),
+        ("parallax", "the hero uses background-size: cover, so moving backgroundPosition exposes blank space"),
+        ("progress-cont", "no .progress-cont span exists in the markup"),
+    ]
+    for token, reason in banned:
+        if token in js:
+            fail("js/main.js still references %r: %s." % (token, reason))
+
+    if facts.parallax:
+        fail(
+            "index.html still puts the parallax class on <%s>, but nothing "
+            "implements it." % ">, <".join(facts.parallax)
+        )
+
+
+def check_syntax():
+    """Optional: node is a convenience here, never a project dependency."""
+    if shutil.which("node") is None:
+        print("skip: node not found, cannot syntax-check js/main.js")
+        return
+    result = subprocess.run(
+        ["node", "--check", str(MAIN_JS)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail("js/main.js is not valid JavaScript:\n%s" % result.stderr.strip())
+
+
+def main():
+    html = INDEX.read_text(encoding="utf-8")
+    js = MAIN_JS.read_text(encoding="utf-8")
+    css = STYLE_CSS.read_text(encoding="utf-8")
+
+    facts = IndexFacts()
+    facts.feed(html)
+
+    check_script_tag(facts)
+    check_nav_targets(facts)
+    check_progress_bars(facts)
+    check_card_handler(html)
+    check_scroll_up_transition(css)
+    check_no_dead_code(facts, js)
+    check_syntax()
+
+    if failures:
+        print("FAIL: %d check(s) failed\n" % len(failures))
+        for message in failures:
+            print("  - %s" % message)
+        return 1
+
+    print("PASS: site interactivity is wired up")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`js/main.js` lost its `<script>` tag in `eba0f7b` and has been dead ever since, taking the sticky navbar, smooth scrolling, active-link tracking, mobile nav collapse, the scroll-to-top button, and the skill bars with it.

This strips the file from 664 lines to 184 by deleting every block whose target element no page contains (magnific-popup, owl carousel, isotope, imagesLoaded, particles, the typer and AJAX contact-form comment blocks, and the `jQuery.scrollSpeed` wheel hijack), adds the script tag back, and fixes the markup the surviving code depends on.

## Two defects found while verifying

**`.portfolio-overlay` swallowed every click.** It covers each card at `z-index: 3` above the content at `z-index: 2` with no `pointer-events`, and an `opacity: 0` element is still hit-testable. A real click on "Code" hit-tested to `div.portfolio-overlay`, never the anchor. So the double-tab bug described in the issue could not actually occur, and the real defect was worse: the Live Demo and Code links were unreachable, and every click opened the homepage regardless of which link you aimed at. Fixed with `pointer-events: none`, which also makes the `closest('a')` guard live and necessary.

**`.scroll-up` was invisible but still clickable.** It was `opacity: 0` with no `visibility` or `pointer-events`, so it sat as a tab-focusable target over the bottom-right corner of every page at all times.

## Beyond the issue text

Three small additions, each because leaving it out would make an acceptance criterion fail on inspection:

- Scroll targets clear the fixed navbar. `navHeight()` subtracts an open `.navbar-collapse`, since below the Bootstrap breakpoint the expanded dropdown is in flow inside the fixed header and measures 278px against the 63px it collapses back to.
- `prefers-reduced-motion` is honored. The site jumped instantly before, so introducing animation without this would have been a new regression.
- `noopener` on the card's `window.open`. Browsers imply it for `target="_blank"` anchors but not for `window.open`.

The scroll handler is throttled to one pass per frame with `requestAnimationFrame`, and runs once on ready so a deep link or a reload partway down the page starts in the right state.

## Test evidence

The repo has no test runner, so `tools/verify_interactivity.py` is the new automated gate (standard library only, `node --check` when node happens to be installed).

- `python3 tools/verify_interactivity.py` -> `PASS`, exit 0
- `node --check js/main.js` -> exit 0
- Vacuity proof: each of the 8 checks was individually reverted in a scratch copy and every breakage was caught

Browser drive at 1440x900 and 500x760:

| Criterion | Observed |
|---|---|
| Navbar sticky past 100px | absent at scrollY 99.74, present at 101.40 |
| Nav links smooth-scroll | mid-flight y=8 -> 815 (ABOUT), 14 -> 2614 (PORTFOLIO), 15 -> 3942 (CONTACT) |
| `data-speed` honored | 1000/1400/1700ms -> 1203/1616/1928ms elapsed |
| Active link tracks section | HOME, ABOUT, SERVICES, PORTFOLIO, CONTACT all highlight |
| Mobile nav closes | `.in` removed, height 0, scroll still completes |
| Nav link lands correctly on mobile | gap below navbar 215px -> 0px |
| Scroll-to-top | hidden and unclickable below 1000, visible above, animates 2468 -> 0, no hash pollution |
| Skill bars animate | 5% -> caught mid-flight at 14.3/12.7/12.7 -> settled 90/75/75 |
| Exactly one tab per click | card body 1 (`window.open` + `noopener`), Code 1 (anchor only), Live Demo 1 (anchor only), using real positional clicks |
| No console errors | zero errors, zero warnings on clean load |

Also drove three paths the issue did not ask for: GitHub API dead (loader still hides, error copy renders, all interactions still work), `prefers-reduced-motion` (jumps instantly), and deep-link `#contact` (navbar sticky, CONTACT active, bars done, with no scroll event).

## Docs reconciled

- `CLAUDE.md`: updated, but **could not ship in this PR**. `.gitignore` line 120 (`/C*.md`) makes it untracked, so the edit lives only in the local checkout. That is #23. It now documents main.js as loaded, the "every block needs a matching element" rule, the `data-percent` and `navHeight()` invariants, why there is no parallax, and why `.portfolio-overlay` must keep `pointer-events: none`. Navigation and Visual Effects are described by function name instead of line number so they do not go stale again.
- `README.md`, `ARCHITECTURE.md`, `CONTEXT.md`, `ONBOARDING.md`, `AGENTS.md`: no change needed, the repo keeps none of them.
- ADR: none. No hard-to-reverse decision worth one.

## Note

The unmerged `issue-15-performance-homepage-assets` branch has staged, uncommitted `index.html` edits that will conflict with this one.

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)
